### PR TITLE
If RuboCop is available, autoformat the created files

### DIFF
--- a/lib/arb/files/solution.rb
+++ b/lib/arb/files/solution.rb
@@ -13,6 +13,8 @@ module Arb
           File.write(file_path, template(year:, day:))
         end
 
+        Formatter.format(file_path)
+
         file_path
       end
 

--- a/lib/arb/files/spec.rb
+++ b/lib/arb/files/spec.rb
@@ -13,6 +13,8 @@ module Arb
           File.write(file_path, template(year:, day:))
         end
 
+        Formatter.format(file_path)
+
         file_path
       end
 

--- a/lib/arb/formatter.rb
+++ b/lib/arb/formatter.rb
@@ -1,0 +1,22 @@
+begin
+  gem 'rubocop'
+  require 'rubocop'
+rescue LoadError
+  # If RuboCop isn't available, no formatting will be done
+end
+
+module Formatter
+  class << self
+    def format(file_path)
+      return unless rubocop_loaded?
+
+      RuboCop::CLI.new.run(['-A', file_path, '--out', File::NULL])
+    end
+
+    private
+
+    def rubocop_loaded?
+      defined?(RuboCop)
+    end
+  end
+end


### PR DESCRIPTION
Passes the files created by `Files::Solution` and `Files::Spec` through RuboCop if available, so that the bootstrapped files conform to the repository's configuration.

If the `rubocop` gem is not available, nothing will happen. This should work with or without `advent_of_ruby` being run through bundler.